### PR TITLE
Allow setting EFM detach.on.agent.failure property.

### DIFF
--- a/roles/setup_efm/defaults/main.yml
+++ b/roles/setup_efm/defaults/main.yml
@@ -108,6 +108,7 @@ pcp_passfile_owner: "efm"
 pcp_passfile_group: "efm"
 pcp_passfile_mode: "0600"
 pgpool2_pcp_port: 9898
+detach_on_agent_failure: true
 
 supported_os:
   - CentOS7

--- a/roles/setup_efm/tasks/efm_configure.yml
+++ b/roles/setup_efm/tasks/efm_configure.yml
@@ -46,6 +46,7 @@
       - {name: custom.monitor.interval, value: "5"}
       - {name: custom.monitor.safe.mode, value: "true"}
       - {name: custom.monitor.timeout, value: "10"}
+      - {name: detach.on.agent.failure, value: "{{ detach_on_agent_failure }}"}
   when:
     - efm_pgpool2_integration
 


### PR DESCRIPTION
Keeping the default as true.