### PR TITLE
Add run_once to PgPool test user creation

### DIFF
--- a/roles/setup_pgpool2/tasks/validate_setup_pgpool2.yml
+++ b/roles/setup_pgpool2/tasks/validate_setup_pgpool2.yml
@@ -123,6 +123,7 @@
         pg_database: "{{ pg_pgpool_database }}"
   no_log: "{{ disable_logging }}"
   when: pgpool2_test_user_password|length > 1
+  run_once: true
 
 - name: Add pgpool2_test_user
   ansible.builtin.include_role:
@@ -181,6 +182,7 @@
         state: absent
   no_log: "{{ disable_logging }}"
   when: pgpool2_test_user_password|length > 1
+  run_once: true
 
 - name: Remove pgpool2_test_user from pgpool2
   ansible.builtin.include_role:


### PR DESCRIPTION
In some cases I have found that the task to create the PgPool test user can run multiple times, with runs subsequent from the first failing with a duplicate key error (the user already exists on the backend after the first run). This patch prevents that from occurring.