### PR TITLE
Fix assertion error caused by YAML >- line continuation character

### DIFF
--- a/roles/manage_dbserver/tasks/validate_manage_dbserver.yml
+++ b/roles/manage_dbserver/tasks/validate_manage_dbserver.yml
@@ -80,8 +80,7 @@
 
 - name: Isolate desired value from query result
   ansible.builtin.set_fact:
-    pg_users_query_names: >-
-      "{{ pg_users_query_result.results | selectattr('query_result', 'defined') | map(attribute='query_result') | flatten | map(attribute='usename') }}"
+    pg_users_query_names: "{{ pg_users_query_result.results | selectattr('query_result', 'defined') | map(attribute='query_result') | flatten | map(attribute='usename') }}"
     pg_users_names: "{{ pg_users | map(attribute='name') }}"
   when: pg_users|length > 0
 
@@ -211,8 +210,7 @@
 
 - name: Isolate desired value from query result
   ansible.builtin.set_fact:
-    pg_slots_query_names: >-
-      "{{ slot_query.results | selectattr('query_result', 'defined') | map(attribute='query_result') | flatten | map(attribute='slot_name') }}"
+    pg_slots_query_names: "{{ slot_query.results | selectattr('query_result', 'defined') | map(attribute='query_result') | flatten | map(attribute='slot_name') }}"
     pg_slots_names: "{{ pg_slots | map(attribute='name') }}"
   when:
     - pg_slots|length > 0
@@ -310,8 +308,7 @@
 
 - name: Isolate desired value from query result
   ansible.builtin.set_fact:
-    pg_roles_query_names: >-
-      "{{ role_query.results | selectattr('query_result', 'defined') | map(attribute='query_result') | flatten | map(attribute='rolname') }}"
+    pg_roles_query_names: "{{ role_query.results | selectattr('query_result', 'defined') | map(attribute='query_result') | flatten | map(attribute='rolname') }}"
     pg_roles_names: "{{ pg_grant_roles | map(attribute='role') }}"
   run_once: true
   when:


### PR DESCRIPTION
The `>-` line continuation character causes the query result list to be converted into a string. This prevents the assertion from doing a real comparison of the two lists, and causes an assertion failure.